### PR TITLE
DST-284 - Adding a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# The DDaT Service Sanctions team maintain Report a Breach
+* @uktrade/service-sanctions


### PR DESCRIPTION
Samia wants better visibility on how who owns what in DBT, to this end we should add a [CODEOWNERS](https://www.arnica.io/blog/what-every-developer-should-know-about-github-codeowners) file to the report-a-breach repo which stores the name of the team that owns the project.