### PR TITLE
Sanctions selected should be displayed to the end user

### DIFF
--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -97,10 +97,6 @@ class ReportABreachWizardView(BaseWizardView):
 
         cleaned_data = self.get_all_cleaned_data()
         context["form_data"] = cleaned_data
-        regimes = cleaned_data["which_sanctions_regime"]
-        context["sanctions_regimes"] = regimes["which_sanctions_regime"]
-        context["unknown_regime"] = regimes["unknown_regime"]
-        context["other_regime"] = regimes["other_regime"]
         context["is_company_obtained_from_companies_house"] = show_check_company_details_page_condition(self)
         context["is_third_party_relationship"] = show_name_and_business_you_work_for_page(self)
         return context

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -97,6 +97,10 @@ class ReportABreachWizardView(BaseWizardView):
 
         cleaned_data = self.get_all_cleaned_data()
         context["form_data"] = cleaned_data
+        regimes = cleaned_data["which_sanctions_regime"]
+        context["sanctions_regimes"] = regimes["which_sanctions_regime"]
+        context["unknown_regime"] = regimes["unknown_regime"]
+        context["other_regime"] = regimes["other_regime"]
         context["is_company_obtained_from_companies_house"] = show_check_company_details_page_condition(self)
         context["is_third_party_relationship"] = show_name_and_business_you_work_for_page(self)
         return context

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -148,11 +148,20 @@
                         Sanctions regimes breached
                     </dt>
                     <dd class="govuk-summary-list__value">
-                        N/A
+                        {% for regime in sanctions_regimes %}
+                            {{ regime }}
+                            <br>
+                        {% endfor %}
+                        {% if unknown_regime %}
+                            Unknown regime
+                        {% endif %}
+                        {% if other_regime %}
+                            Other regime
+                        {% endif %}
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <a class="govuk-link"
-                           href="{% get_wizard_step_url 'business_or_person_details' %}?redirect=summary">Change<span
+                           href="{% get_wizard_step_url 'which_sanctions_regime' %}?redirect=summary">Change<span
                             class="govuk-visually-hidden"> {# todo - hidden copy #}</span></a>
                     </dd>
                 </div>

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -148,14 +148,14 @@
                         Sanctions regimes breached
                     </dt>
                     <dd class="govuk-summary-list__value">
-                        {% for regime in sanctions_regimes %}
+                        {% for regime in form_data.which_sanctions_regime.which_sanctions_regime %}
                             {{ regime }}
                             <br>
                         {% endfor %}
-                        {% if unknown_regime %}
-                            Unknown regime
+                        {% if form_data.which_sanctions_regime.unknown_regime %}
+                            Unknown regime<br>
                         {% endif %}
-                        {% if other_regime %}
+                        {% if form_data.which_sanctions_regime.other_regime %}
                             Other regime
                         {% endif %}
                     </dd>


### PR DESCRIPTION
This was removed accidentally in another PR.
The sanctions ticked on the which_sanctions_regime page will be displayed again to the end user on the summary page.

![image](https://github.com/uktrade/report-a-breach-prototype/assets/150944262/4cbc787c-b02c-4d8a-8c21-b373f82fc81d)
