### PR TITLE
DST-301: Fix redirect logic from the summary page

### DIFF
--- a/report_a_breach/base_classes/views.py
+++ b/report_a_breach/base_classes/views.py
@@ -51,9 +51,10 @@ class BaseWizardView(NamedUrlSessionWizardView):
             return super().render(form, **kwargs)
         # if we have a redirect set in the session, we want to redirect to that step, but only if the form is valid.
         # if the form is not valid, we want to show the user the errors on the current step
-        elif redirect_to := self.request.session.get("redirect") and form.is_valid():
-            self.request.session["redirect"] = None
-            return self.render_goto_step(redirect_to)
+        elif redirect_to := self.request.session.get("redirect"):
+            if form.is_valid():
+                self.request.session["redirect"] = None
+                return self.render_goto_step(redirect_to)
         return super().render(form, **kwargs)
 
     def post(self, *args, **kwargs):


### PR DESCRIPTION
The assignment to redirect_to in the render method was a boolean which meant the actual redirect page name wasn't passed into the render_goto_step method. This is corrected by moving the if form.is_valid into a separate condition check.
