### PR TITLE
DST-323: Fix user journey when companies house number is unknown

### DIFF
--- a/report_a_breach/core/form_step_conditions.py
+++ b/report_a_breach/core/form_step_conditions.py
@@ -18,15 +18,12 @@ def show_check_company_details_page_condition(wizard):
 
 def show_where_is_the_address_of_the_business_or_person_page_condition(wizard):
     cleaned_data = wizard.get_cleaned_data_for_step("are_you_reporting_a_business_on_companies_house")
-    return cleaned_data.get("business_registered_on_companies_house", False) == "no"
+    return cleaned_data.get("business_registered_on_companies_house", False) in ["no", "do_not_know"]
 
 
 def show_do_you_know_the_registered_company_number_page(wizard):
     cleaned_data = wizard.get_cleaned_data_for_step("are_you_reporting_a_business_on_companies_house")
-    return cleaned_data.get("business_registered_on_companies_house", False) in [
-        "yes",
-        "do_not_know",
-    ]
+    return cleaned_data.get("business_registered_on_companies_house", False) == "yes"
 
 
 def show_about_the_supplier_page(wizard):

--- a/report_a_breach/core/forms.py
+++ b/report_a_breach/core/forms.py
@@ -133,6 +133,10 @@ class AreYouReportingABusinessOnCompaniesHouseForm(BaseModelForm):
             "business_registered_on_companies_house": "Are you reporting a business which is registered with Companies House?"
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["business_registered_on_companies_house"].choices.pop(0)
+
 
 class DoYouKnowTheRegisteredCompanyNumberForm(BaseModelForm):
     hide_optional_label_fields = ["registered_company_number"]


### PR DESCRIPTION
JIRA ticket: https://uktrade.atlassian.net/browse/DST-323

This ticket fixes a bug in the user journey where previously when the user selected "I do not know" on the "are you reporting a company registered on companies house" form, they would continue onto the "do you know the registered company number" form.
Now, the user will continue to "Where is the address of the person who made the suspected breach" form.