### PR TITLE
Dst 332/bugfix cya page

### DIFF
--- a/report_a_breach/base_classes/views.py
+++ b/report_a_breach/base_classes/views.py
@@ -49,8 +49,18 @@ class BaseWizardView(NamedUrlSessionWizardView):
         return super().process_step(form)
 
     def render(self, form=None, **kwargs):
-        if self.steps.current == "verify":
+
+        steps_to_continue = [
+            "verify",
+            "business_or_person_details",
+            "check_company_details",
+            "about_the_supplier",
+            "about_the_end_user",
+        ]
+
+        if self.steps.current in steps_to_continue:
             return super().render(form, **kwargs)
+
         # if we have a redirect set in the session, we want to redirect to that step, but only if the form is valid.
         # if the form is not valid, we want to show the user the errors on the current step
         elif redirect_to := self.request.session.get("redirect"):

--- a/report_a_breach/core/forms.py
+++ b/report_a_breach/core/forms.py
@@ -525,6 +525,13 @@ class EndUserAddedForm(BaseForm):
         self.helper.legend_size = Size.MEDIUM
         self.helper.legend_tag = None
 
+    def is_valid(self):
+        # todo - we need to set this as True always for now, as the form really only gets validated
+        #  with a corresponding end_user_uuid, so we can't validate it here
+        #  we need to override render_done() in the WizardView so the resulting form_list
+        #  contains all instances of this form for each end_user
+        return super().is_valid() or True
+
 
 class WereThereOtherAddressesInTheSupplyChainForm(BaseModelForm):
     hide_optional_label_fields = ["other_addresses_in_the_supply_chain"]

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -335,6 +335,7 @@ class ReportABreachWizardView(BaseWizardView):
         self.upload_documents_to_s3()
         new_breach = Breach.objects.create()
         new_reference = new_breach.assign_reference()
+        del self.request.session["end_users"]
         self.request.session["reference_id"] = new_reference
         self.storage.reset()
         self.storage.current_step = self.steps.first

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -131,7 +131,8 @@ class ReportABreachWizardView(BaseWizardView):
 
         if uploaded_file_name := self.request.session.get("uploaded_file_name", None):
             context["form_data"]["uploaded_file_name"] = uploaded_file_name
-
+        if end_users := self.request.session.get("end_users", None):
+            context["form_data"]["end_users"] = end_users
         return context
 
     def process_are_you_reporting_a_business_on_companies_house_step(self, form):

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -286,14 +286,13 @@ class ReportABreachWizardView(BaseWizardView):
         """
         cleaned_data = {}
         for form_key in self.get_form_list():
-            if form_key == "about_the_end_user":
+            if form_key == "about_the_end_user" or form_key == "end_user_added":
                 continue
             form_obj = self.get_form(
                 step=form_key, data=self.storage.get_step_data(form_key), files=self.storage.get_step_files(form_key)
             )
             if form_obj.is_valid():
                 cleaned_data[form_key] = form_obj.cleaned_data
-
         return cleaned_data
 
     def upload_documents_to_s3(self):

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -111,17 +111,6 @@ class ReportABreachWizardView(BaseWizardView):
             # we want to redirect them to 'where is the end user' page, but pass another query parameter to indicate that they
             # know about another end-user, so we can remove the last option 'I don't know' from the list of options
             return redirect(f"{self.get_step_url('where_were_the_goods_supplied_to')}?add_another_end_user=yes")
-
-        if (
-            self.steps.current == "do_you_know_the_registered_company_number"
-            and self.request.GET.get("change_company_number") == "yes"
-        ):
-            # If they know the number, show companies house details and then redirect back to summary
-            # If not, show business or person details (uk address) and then redirect back to summary
-            if form.cleaned_data["do_you_know_the_registered_company_number"] == "yes":
-                return redirect(f"{self.get_step_url('check_company_details')}?redirect=summary")
-            else:
-                return redirect(f"{self.get_step_url('business_or_person_details')}?redirect=summary")
         return super().render_next_step(form, **kwargs)
 
     def get_summary_context_data(self, form, context):

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -111,6 +111,15 @@ class ReportABreachWizardView(BaseWizardView):
             # we want to redirect them to 'where is the end user' page, but pass another query parameter to indicate that they
             # know about another end-user, so we can remove the last option 'I don't know' from the list of options
             return redirect(f"{self.get_step_url('where_were_the_goods_supplied_to')}?add_another_end_user=yes")
+        if (
+            self.steps.current == "do_you_know_the_registered_company_number"
+            and self.request.GET.get("change_company_number") == "yes"
+        ):
+            # want to show companies house details and then redirect back to summary
+            # if yes:
+            return redirect(f"{self.get_step_url('check_company_details')}?redirect=summary")
+            # if no:
+
         return super().render_next_step(form, **kwargs)
 
     def get_summary_context_data(self, form, context):

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -144,7 +144,13 @@ class ReportABreachWizardView(BaseWizardView):
         if end_users := self.request.session.get("end_users", None):
             context["form_data"]["end_users"] = end_users
         if context["form_data"]["where_were_the_goods_supplied_from"]["where_were_the_goods_supplied_from"] == "same_address":
-            context["form_data"]["about_the_supplier"] = context["form_data"]["business_or_person_details"]
+            if show_check_company_details_page_condition(self):
+                registered_company = context["form_data"]["do_you_know_the_registered_company_number"]
+                context["form_data"]["about_the_supplier"] = {}
+                context["form_data"]["about_the_supplier"]["name"] = registered_company["registered_company_name"]
+                context["form_data"]["about_the_supplier"]["readable_address"] = registered_company["registered_office_address"]
+            else:
+                context["form_data"]["about_the_supplier"] = context["form_data"]["business_or_person_details"]
         return context
 
     def process_are_you_reporting_a_business_on_companies_house_step(self, form):

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -111,18 +111,17 @@ class ReportABreachWizardView(BaseWizardView):
             # we want to redirect them to 'where is the end user' page, but pass another query parameter to indicate that they
             # know about another end-user, so we can remove the last option 'I don't know' from the list of options
             return redirect(f"{self.get_step_url('where_were_the_goods_supplied_to')}?add_another_end_user=yes")
+
         if (
             self.steps.current == "do_you_know_the_registered_company_number"
             and self.request.GET.get("change_company_number") == "yes"
         ):
-            # want to show companies house details and then redirect back to summary
-            # if yes:
+            # If they know the number, show companies house details and then redirect back to summary
+            # If not, show business or person details (uk address) and then redirect back to summary
             if form.cleaned_data["do_you_know_the_registered_company_number"] == "yes":
                 return redirect(f"{self.get_step_url('check_company_details')}?redirect=summary")
             else:
                 return redirect(f"{self.get_step_url('business_or_person_details')}?redirect=summary")
-            # if no:
-
         return super().render_next_step(form, **kwargs)
 
     def get_summary_context_data(self, form, context):

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -143,6 +143,8 @@ class ReportABreachWizardView(BaseWizardView):
             context["form_data"]["uploaded_file_name"] = uploaded_file_name
         if end_users := self.request.session.get("end_users", None):
             context["form_data"]["end_users"] = end_users
+        if context["form_data"]["where_were_the_goods_supplied_from"]["where_were_the_goods_supplied_from"] == "same_address":
+            context["form_data"]["about_the_supplier"] = context["form_data"]["business_or_person_details"]
         return context
 
     def process_are_you_reporting_a_business_on_companies_house_step(self, form):
@@ -291,6 +293,7 @@ class ReportABreachWizardView(BaseWizardView):
             )
             if form_obj.is_valid():
                 cleaned_data[form_key] = form_obj.cleaned_data
+
         return cleaned_data
 
     def upload_documents_to_s3(self):

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -117,7 +117,10 @@ class ReportABreachWizardView(BaseWizardView):
         ):
             # want to show companies house details and then redirect back to summary
             # if yes:
-            return redirect(f"{self.get_step_url('check_company_details')}?redirect=summary")
+            if form.cleaned_data["do_you_know_the_registered_company_number"] == "yes":
+                return redirect(f"{self.get_step_url('check_company_details')}?redirect=summary")
+            else:
+                return redirect(f"{self.get_step_url('business_or_person_details')}?redirect=summary")
             # if no:
 
         return super().render_next_step(form, **kwargs)

--- a/report_a_breach/templates/form_steps/end_user_added.html
+++ b/report_a_breach/templates/form_steps/end_user_added.html
@@ -4,8 +4,7 @@
 
 {% block form_content %}
     <h1 class="govuk-heading-l">
-        You've added {{ request.session.end_users.keys|length }} end-user{% if request.session.end_users.keys|length > 1 %}
-            s{% endif %}
+        You've added {{ request.session.end_users.keys|length }} end-user{% if request.session.end_users.keys|length > 1 %}s{% endif %}
     </h1>
     {% for id, end_user in request.session.end_users.items %}
         <h3 class="govuk-heading-m">End-user {{ forloop.counter }}</h3>

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -231,8 +231,9 @@
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <a class="govuk-link"
-                           href="{% url 'report_a_breach_about_the_end_user' end_user_uuid=end_user%}?redirect=summary">Change<span
-                            class="govuk-visually-hidden"></span></a>
+                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                            class="govuk-visually-hidden"> </span></a>
+
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row">

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -68,7 +68,7 @@
             <dd class="govuk-summary-list__actions">
                 {% if is_company_obtained_from_companies_house %}
                     <a class="govuk-link"
-                       href="{% get_wizard_step_url 'do_you_know_the_registered_company_number' %}?redirect=summary">Change<span
+                       href="{% get_wizard_step_url 'do_you_know_the_registered_company_number' %}?change_company_number=yes">Change<span
                         class="govuk-visually-hidden"></span></a>
                 {% else %}
                     <a class="govuk-link"

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -214,104 +214,57 @@
         </div>
     </dl>
     <h2 class="govuk-heading-m">End-user of the goods or services</h2>
-    <h2 class="govuk-heading-s">End-user 1</h2>
-    <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-!-font-weight-regular">
-                Name of person
-            </dt>
-            <dd class="govuk-summary-list__value">
-{#                        TODO: this does not appear in the cleaned data #}
-                {{ form_data.where_were_the_goods_supplied_to.name }}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-                <a class="govuk-link"
-                   href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
-                    class="govuk-visually-hidden"></span></a>
-            </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-!-font-weight-regular">
-                Address
-            </dt>
-            <dd class="govuk-summary-list__value">
-{#                        TODO: this does not appear in the cleaned data #}
-                {{ form_data.where_were_the_goods_supplied_to.where_were_the_goods_supplied_to }}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-                <a class="govuk-link"
-                   href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
-                    class="govuk-visually-hidden"> </span></a>
+    {% if form_data.end_users %}
+        {% for end_user, value in form_data.end_users.items %}
+            <h2 class="govuk-heading-s">End-user {{ forloop.counter }}</h2>
+            <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-!-font-weight-regular">
+                        Name of person
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ value.cleaned_data.name_of_person }}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link"
+                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                            class="govuk-visually-hidden"></span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-!-font-weight-regular">
+                        Address
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ value.cleaned_data.readable_address | linebreaksbr }}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link"
+                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                            class="govuk-visually-hidden"> </span></a>
 
-            </dd>
-        </div>
-        <div class="govuk-summary-list__row">
-            <dt class="govuk-!-font-weight-regular">
-                Additional information
-            </dt>
-            <dd class="govuk-summary-list__value">
-{#                        TODO: this does not appear in the cleaned data #}
-                {{ form_data.where_were_the_goods_supplied_to.additional_details }}
-            </dd>
-            <dd class="govuk-summary-list__actions">
-                <a class="govuk-link"
-                   href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
-                    class="govuk-visually-hidden"> </span></a>
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-!-font-weight-regular">
+                        Additional information
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ value.cleaned_data.additional_contact_details }}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link"
+                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                            class="govuk-visually-hidden"> </span></a>
 
-            </dd>
-        </div>
-        {% if form_data.where_were_the_goods_supplied_to.end_users %}
-            {% for end_user in form_data.where_were_the_goods_supplied_to.end_users %}
-{#        TODO: cannot find additional end user details in the cleaned data #}
-{#        The below represents what might be needed when the data is available#}
-                <h2 class="govuk-heading-s">End-user 1</h2>
-                <dl class="govuk-summary-list">
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-!-font-weight-regular">
-                            Name of person
-                        </dt>
-                        <dd class="govuk-summary-list__value">
-{#                        TODO: this does not appear in the cleaned data #}
-                            {{ end_user.name }}
-                        </dd>
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link"
-                               href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
-                                class="govuk-visually-hidden"></span></a>
-                        </dd>
-                    </div>
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-!-font-weight-regular">
-                            Address
-                        </dt>
-                        <dd class="govuk-summary-list__value">
-                            {{ end_user.where_were_the_goods_supplied_to }}
-                        </dd>
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link"
-                               href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
-                                class="govuk-visually-hidden"> </span></a>
-
-                        </dd>
-                    </div>
-                    <div class="govuk-summary-list__row">
-                        <dt class="govuk-!-font-weight-regular">
-                            Additional information
-                        </dt>
-                        <dd class="govuk-summary-list__value">
-{#                        TODO: this does not appear in the cleaned data #}
-                            {{ end_user.additional_details }}
-                        </dd>
-                        <dd class="govuk-summary-list__actions">
-                            <a class="govuk-link"
-                               href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
-                                class="govuk-visually-hidden"> </span></a>
-
-                        </dd>
-                    </div>
-            {% endfor %}
-        {% endif %}
-    </dl>
+                    </dd>
+                </div>
+            </dl>
+        {% endfor %}
+    {% endif %}
+    <a class="govuk-link"
+       href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Add end-user<span
+        class="govuk-visually-hidden"></span></a>
  {#    TODO: need to add conditional here for other addresses in the supply chain #}
     <h2 class="govuk-heading-m">Sanctions breach details</h2>
     <dl class="govuk-summary-list">

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -189,7 +189,11 @@
                 Website
             </dt>
             <dd class="govuk-summary-list__value">
-                {{ form_data.about_the_supplier.website }}
+                {% if form_data.about_the_supplier.website %}
+                    <a class="govuk-link"
+                       href="{{ form_data.about_the_supplier.website }}">{{ form_data.about_the_supplier.website }}<span
+                        class="govuk-visually-hidden"> </span></a>
+                {% endif %}
             </dd>
             <dd class="govuk-summary-list__actions">
                 <a class="govuk-link"
@@ -233,6 +237,24 @@
                 </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-!-font-weight-regular">
+                        Website
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        {% if value.cleaned_data.website %}
+                            <a class="govuk-link"
+                               href="{{value.cleaned_data.website }}">{{ value.cleaned_data.website }}<span
+                                class="govuk-visually-hidden"> </span></a>
+                        {% endif %}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                        <a class="govuk-link"
+                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                            class="govuk-visually-hidden"> </span></a>
+
+                    </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-!-font-weight-regular">
                         Address
                     </dt>
                     <dd class="govuk-summary-list__value">
@@ -262,9 +284,11 @@
             </dl>
         {% endfor %}
     {% endif %}
-    <a class="govuk-link"
-       href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Add end-user<span
-        class="govuk-visually-hidden"></span></a>
+    <dl class="govuk-summary-list">
+        <a class="govuk-link"
+           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Add end-user<span
+            class="govuk-visually-hidden"></span></a>
+    </dl>
  {#    TODO: need to add conditional here for other addresses in the supply chain #}
     <h2 class="govuk-heading-m">Sanctions breach details</h2>
     <dl class="govuk-summary-list">

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -231,7 +231,7 @@
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <a class="govuk-link"
-                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                           href="{% url 'report_a_breach_about_the_end_user' end_user_uuid=end_user%}?redirect=summary">Change<span
                             class="govuk-visually-hidden"></span></a>
                     </dd>
                 </div>

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -68,7 +68,7 @@
             <dd class="govuk-summary-list__actions">
                 {% if is_company_obtained_from_companies_house %}
                     <a class="govuk-link"
-                       href="{% get_wizard_step_url 'do_you_know_the_registered_company_number' %}?change_company_number=yes">Change<span
+                       href="{% get_wizard_step_url 'do_you_know_the_registered_company_number' %}?redirect=summary">Change<span
                         class="govuk-visually-hidden"></span></a>
                 {% else %}
                     <a class="govuk-link"

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -85,7 +85,7 @@
                 {% if is_company_obtained_from_companies_house %}
                     {{ form_data.do_you_know_the_registered_company_number.registered_company_name }}
                 {% else %}
-                    N/A
+                    {{ form_data.business_or_person_details.name }}
                 {% endif %}
             </dd>
             <dd class="govuk-summary-list__actions">
@@ -103,9 +103,9 @@
             </dt>
             <dd class="govuk-summary-list__value">
                 {% if is_company_obtained_from_companies_house %}
-                    {{ form_data.do_you_know_the_registered_company_number.registered_office_address }}
+                    {{ form_data.do_you_know_the_registered_company_number.registered_office_address | linebreaksbr }}
                 {% else %}
-                    N/A
+                    {{ form_data.business_or_person_details.readable_address | linebreaksbr }}
                 {% endif %}
             </dd>
             <dd class="govuk-summary-list__actions">
@@ -176,8 +176,7 @@
                 Name
             </dt>
             <dd class="govuk-summary-list__value">
-{#                        TODO: this does not appear in the cleaned data #}
-                {{ form_data.where_were_the_goods_supplied_from.name }}
+                {{ form_data.about_the_supplier.name }}
             </dd>
             <dd class="govuk-summary-list__actions">
                 <a class="govuk-link"
@@ -190,8 +189,7 @@
                 Website
             </dt>
             <dd class="govuk-summary-list__value">
-{#                        TODO: this does not appear in the cleaned data #}
-                {{ form_data.where_were_the_goods_supplied_from.website }}
+                {{ form_data.about_the_supplier.website }}
             </dd>
             <dd class="govuk-summary-list__actions">
                 <a class="govuk-link"
@@ -205,8 +203,7 @@
                 Address
             </dt>
             <dd class="govuk-summary-list__value">
-{#                        TODO: this does not appear in the cleaned data #}
-                {{ form_data.where_were_the_goods_supplied_from.address }}
+                {{ form_data.about_the_supplier.readable_address | linebreaksbr }}
             </dd>
             <dd class="govuk-summary-list__actions">
                 <a class="govuk-link"

--- a/report_a_breach/utils/companies_house.py
+++ b/report_a_breach/utils/companies_house.py
@@ -34,13 +34,15 @@ def get_formatted_address(address_dict: dict):
         address_string += line_1
 
     if line_2 := address_dict.get("address_line_2"):
-        address_string += f", {line_2}"
+        address_string += f",\n {line_2}"
 
+    if town_or_city := address_dict.get("town_or_city"):
+        address_string += f",\n {town_or_city}"
     if postal_code := address_dict.get("postal_code"):
-        address_string += f", {postal_code}"
+        address_string += f",\n {postal_code}"
 
     # todo - get full country name from country code
     if country := address_dict.get("country"):
-        address_string += f", {country}"
+        address_string += f",\n {country}"
 
     return address_string


### PR DESCRIPTION
Bugfixes for [DST-332](https://uktrade.atlassian.net/browse/DST-332)
- [x] Change link for Registered business number - Goes to correct screen - but once this is changed it should go on to the Company Summary page (and then back to CYA)
- [x] CYA - business of person suspected section  - address styling should be on separate lines, currently this is all together 
- [x] CYA -change link for supplier of goods/ services - address styling should be on separate lines, currently this is all together 
- [x] CYA - if supplier same as reporter, show address details (currently blank)
- [x] CYA -change link for supplier of goods/ services - Clicks though to the right screen, but then should go to the address capture screen chosen on the radio button (need to check with Rebecca)
- [x] CYA - Add end user link - Goes to UK capture form, should go to Where were the goods/services supplied to
- [x] CYA - change link for end user - Same errors as above (need to check with Rebecca) - _This goes to the correct page but doesn't include the end user session ID so it creates a new end user rather than changing the desired user information._ 
- [x] Submitting form keeps end user session data - it should be deleted  

Screenshots for information: 

![image](https://github.com/uktrade/report-a-breach-prototype/assets/65167892/17d5bbc0-c0fa-41e6-8683-276a64b10097)
![image](https://github.com/uktrade/report-a-breach-prototype/assets/65167892/9e211c85-6a3d-49df-bbfc-330872babe0e)



[DST-332]: https://uktrade.atlassian.net/browse/DST-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ