### PR TITLE
Fix 500 error when selecting "have not been supplied yet"

### DIFF
--- a/report_a_breach/base_classes/forms.py
+++ b/report_a_breach/base_classes/forms.py
@@ -26,7 +26,7 @@ class BaseForm(forms.Form):
             "all": ["form.css"],
         }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, address_string=None, *args, **kwargs):
         self.request = kwargs.pop("request", None)
         self.form_h1_header = kwargs.pop("form_h1_header", self.form_h1_header)
         super().__init__(*args, **kwargs)

--- a/report_a_breach/core/forms.py
+++ b/report_a_breach/core/forms.py
@@ -372,11 +372,10 @@ class WhereWereTheGoodsMadeAvailableForm(BaseForm):
         label="Where were the goods, services, technological assistance or technology made available from?",
     )
 
-    def __init__(self, *args, address_dict, **kwargs):
+    def __init__(self, address_string=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         address_choices = []
-        if address_dict:
-            address_string = get_formatted_address(address_dict)
+        if address_string is not None:
             address_choices.append(Choice("same_address", address_string, divider="or"))
 
         address_choices += [


### PR DESCRIPTION
Selecting "They have not been supplied yet" on the "supplied to" page results in a 500 error. This is because the address dict that the "made_available_from" form expects was actually passed in as a string from the kwargs. This PR fixes the error and allows the user to enter the start of the "made available from" journey. More work on the made_available journey to be completed as part of ticket DST-328.