### PR TITLE
DST-328: Create the made_available journey

### DIFF
--- a/report_a_breach/core/form_step_conditions.py
+++ b/report_a_breach/core/form_step_conditions.py
@@ -103,6 +103,3 @@ def show_where_were_the_goods_made_available_to_page(wizard):
         show_page = cleaned_data.get("where_were_the_goods_made_available_from") in ["different_uk_address", "outside_the_uk"]
 
     return show_page
-
-
-# TODO: raise ticket to fix address capture from the made_available_to page

--- a/report_a_breach/core/form_step_conditions.py
+++ b/report_a_breach/core/form_step_conditions.py
@@ -28,14 +28,25 @@ def show_do_you_know_the_registered_company_number_page(wizard):
 
 def show_about_the_supplier_page(wizard):
     cleaned_data = wizard.get_cleaned_data_for_step("where_were_the_goods_supplied_from")
-    return cleaned_data.get("where_were_the_goods_supplied_from", False) in (
-        "different_uk_address",
-        "outside_the_uk",
+    cleaned_data_available = wizard.get_cleaned_data_for_step("where_were_the_goods_made_available_from")
+    choices = ["different_uk_address", "outside_the_uk"]
+
+    show_page = (
+        cleaned_data.get("where_were_the_goods_supplied_from", False) in choices
+        or cleaned_data_available.get("where_were_the_goods_made_available_from", False) in choices
     )
+
+    return show_page
 
 
 def show_where_were_the_goods_made_available_from_page(wizard):
     cleaned_data = wizard.get_cleaned_data_for_step("where_were_the_goods_supplied_from")
+
+    # if this data exists, we have already submitted this form and the user should be directed to the next
+    cleaned_data_available_step = wizard.get_cleaned_data_for_step("where_were_the_goods_made_available_from")
+    if cleaned_data_available_step:
+        return False
+
     return cleaned_data.get("where_were_the_goods_supplied_from", False) == "they_have_not_been_supplied"
 
 
@@ -73,3 +84,25 @@ def show_about_the_end_user_page(wizard):
 def show_end_user_added_page(wizard):
     cleaned_data = wizard.get_cleaned_data_for_step("where_were_the_goods_supplied_to")
     return cleaned_data.get("where_were_the_goods_supplied_to") in ["in_the_uk", "outside_the_uk"]
+
+
+def show_where_were_the_goods_supplied_to_page(wizard):
+    cleaned_data = wizard.get_cleaned_data_for_step("where_were_the_goods_made_available_from")
+    # ensure the supplied_to page is not shown when the user is on the made_available journey
+    return not cleaned_data.get("where_were_the_goods_made_available_from")
+
+
+def show_where_were_the_goods_made_available_to_page(wizard):
+    cleaned_data = wizard.get_cleaned_data_for_step("where_were_the_goods_made_available_from")
+    cleaned_data_supplier_step = wizard.get_cleaned_data_for_step("about_the_supplier")
+    show_page = False
+
+    if not cleaned_data_supplier_step:
+        show_page = cleaned_data.get("where_were_the_goods_made_available_from") in ["same_address", "i_do_not_know"]
+    else:
+        show_page = cleaned_data.get("where_were_the_goods_made_available_from") in ["different_uk_address", "outside_the_uk"]
+
+    return show_page
+
+
+# TODO: raise ticket to fix address capture from the made_available_to page

--- a/report_a_breach/core/forms.py
+++ b/report_a_breach/core/forms.py
@@ -395,7 +395,7 @@ class WhereWereTheGoodsSuppliedToForm(BaseForm):
         ),
         widget=forms.RadioSelect,
         label="Where were the goods, services, technological assistance or technology supplied to?",
-        help_text="This is the adresss of the end-user",
+        help_text="This is the address of the end-user",
     )
 
     def __init__(self, *args, **kwargs):

--- a/report_a_breach/core/forms.py
+++ b/report_a_breach/core/forms.py
@@ -405,6 +405,25 @@ class WhereWereTheGoodsSuppliedToForm(BaseForm):
             self.fields["where_were_the_goods_supplied_to"].choices.pop(-1)
 
 
+class WhereWereTheGoodsMadeAvailableToForm(BaseForm):
+    where_were_the_goods_supplied_to = forms.ChoiceField(
+        choices=(
+            Choice("in_the_uk", "The UK"),
+            Choice("outside_the_uk", "Outside the UK"),
+            Choice("i_do_not_know", "I do not know"),
+        ),
+        widget=forms.RadioSelect,
+        label="Where were the goods, services, technological assistance or technology made available to?",
+        help_text="This is the address of the end-user",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.request.GET.get("add_another_end_user") == "yes":
+            # the user is trying to add another end-user, let's pop the "I do not know" option
+            self.fields["where_were_the_goods_supplied_to"].choices.pop(-1)
+
+
 class AboutTheEndUserForm(BasePersonBusinessDetailsForm):
     form_h1_header = "About the end-user"
     labels = {

--- a/report_a_breach/core/forms.py
+++ b/report_a_breach/core/forms.py
@@ -421,7 +421,7 @@ class WhereWereTheGoodsMadeAvailableToForm(BaseForm):
         super().__init__(*args, **kwargs)
         if self.request.GET.get("add_another_end_user") == "yes":
             # the user is trying to add another end-user, let's pop the "I do not know" option
-            self.fields["where_were_the_goods_made_available_too"].choices.pop(-1)
+            self.fields["where_were_the_goods_made_available_to"].choices.pop(-1)
 
 
 class AboutTheEndUserForm(BasePersonBusinessDetailsForm):

--- a/report_a_breach/core/forms.py
+++ b/report_a_breach/core/forms.py
@@ -406,7 +406,7 @@ class WhereWereTheGoodsSuppliedToForm(BaseForm):
 
 
 class WhereWereTheGoodsMadeAvailableToForm(BaseForm):
-    where_were_the_goods_supplied_to = forms.ChoiceField(
+    where_were_the_goods_made_available_to = forms.ChoiceField(
         choices=(
             Choice("in_the_uk", "The UK"),
             Choice("outside_the_uk", "Outside the UK"),
@@ -421,7 +421,7 @@ class WhereWereTheGoodsMadeAvailableToForm(BaseForm):
         super().__init__(*args, **kwargs)
         if self.request.GET.get("add_another_end_user") == "yes":
             # the user is trying to add another end-user, let's pop the "I do not know" option
-            self.fields["where_were_the_goods_supplied_to"].choices.pop(-1)
+            self.fields["where_were_the_goods_made_available_too"].choices.pop(-1)
 
 
 class AboutTheEndUserForm(BasePersonBusinessDetailsForm):

--- a/report_a_breach/core/urls.py
+++ b/report_a_breach/core/urls.py
@@ -11,6 +11,8 @@ from .form_step_conditions import (
     show_name_page,
     show_where_is_the_address_of_the_business_or_person_page_condition,
     show_where_were_the_goods_made_available_from_page,
+    show_where_were_the_goods_made_available_to_page,
+    show_where_were_the_goods_supplied_to_page,
 )
 from .views import CompleteView, ReportABreachWizardView
 
@@ -26,8 +28,10 @@ report_a_breach_wizard = ReportABreachWizardView.as_view(
         "do_you_know_the_registered_company_number": show_do_you_know_the_registered_company_number_page,
         "about_the_supplier": show_about_the_supplier_page,
         "where_were_the_goods_made_available_from": show_where_were_the_goods_made_available_from_page,
+        "where_were_the_goods_supplied_to": show_where_were_the_goods_supplied_to_page,
         "about_the_end_user": show_about_the_end_user_page,
         "end_user_added": show_end_user_added_page,
+        "where_were_the_goods_made_available_to": show_where_were_the_goods_made_available_to_page,
     },
 )
 

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -197,9 +197,6 @@ class ReportABreachWizardView(BaseWizardView):
     def get_form(self, step=None, data=None, files=None):
         if step is None:
             step = self.steps.current
-        # if step == "where_were_the_goods_made_available_from":
-        #     form_class = self.get_form_list().get(step)
-        # else:
         # we are overriding this method, so we call self.form_list rather than self.get_form_list(). The latter will
         # apply the conditional logic to the form list, which we don't want to do here.
         form_class = self.form_list[step]

--- a/report_a_breach/custom_upload_handler.py
+++ b/report_a_breach/custom_upload_handler.py
@@ -9,7 +9,6 @@ CHUNK_UPLOADER_RAISE_EXCEPTION_ON_VIRUS_FOUND = settings.CHUNK_UPLOADER_RAISE_EX
 
 
 class CustomFileUploadHandler(FileUploadHandler):
-
     def receive_data_chunk(self, raw_data):
         return raw_data
 


### PR DESCRIPTION
This journey starts when the user selects "They have not been supplied yet" on the supplied_to page. 
The next form "made_available_from" should always redirect to the "made_available_to" once the appropriate addresses are captured, if applicable.
The new logic from the made_available_from page is:

- same address -> redirect to made_available_to
- different uk address -> about the supplier address capture -> made_available_to
- outside address -> about the supplier address capture -> made_available_to
- I don't know -> redirect to made_available_to

The end-user address captures should follow from the made_available_to page, however that is not currently working and will be handled in a separate ticket (DST-346).

![image](https://github.com/uktrade/report-a-breach-prototype/assets/150944262/551c3f0b-781a-4ea0-a7da-4a23c5f94608)

