### PR TITLE
Dst 332/end user id change page

### DIFF
--- a/report_a_breach/core/urls.py
+++ b/report_a_breach/core/urls.py
@@ -42,6 +42,11 @@ urlpatterns = [
         report_a_breach_wizard,
         name="report_a_breach_about_the_end_user",
     ),
+    path(
+        "report_a_breach/where_were_the_goods_supplied_to/<str:end_user_uuid>/",
+        report_a_breach_wizard,
+        name="report_a_breach_where_were_the_goods_supplied_to",
+    ),
     re_path(r"report_a_breach/(?P<step>.+)/$", report_a_breach_wizard, name="report_a_breach_step"),
     path("complete", CompleteView.as_view(), name="complete"),
 ]

--- a/report_a_breach/core/views.py
+++ b/report_a_breach/core/views.py
@@ -98,12 +98,22 @@ class ReportABreachWizardView(BaseWizardView):
                 # we're trying to edit an existing end-user, so we need to load the form with the existing data
                 self.storage.current_step = "about_the_end_user"
                 return super().get(request, *args, step="about_the_end_user", **kwargs)
+
+        if request.resolver_match.url_name == "report_a_breach_where_were_the_goods_supplied_to":
+            self.storage.current_step = "where_were_the_goods_supplied_to"
+            return super().get(request, *args, step="where_were_the_goods_supplied_to", **kwargs)
         return super().get(request, *args, **kwargs)
 
     def get_step_url(self, step):
         if step == "about_the_end_user" and "end_user_uuid" in self.kwargs:
             return reverse(
                 "report_a_breach_about_the_end_user",
+                kwargs={"end_user_uuid": self.kwargs["end_user_uuid"]},
+            )
+
+        if step == "where_were_the_goods_supplied_to" and "end_user_uuid" in self.kwargs:
+            return reverse(
+                "report_a_breach_where_were_the_goods_supplied_to",
                 kwargs={"end_user_uuid": self.kwargs["end_user_uuid"]},
             )
         return super().get_step_url(step)

--- a/report_a_breach/templates/form_steps/summary.html
+++ b/report_a_breach/templates/form_steps/summary.html
@@ -231,9 +231,8 @@
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <a class="govuk-link"
-                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                           href="{% url 'report_a_breach_where_were_the_goods_supplied_to' end_user_uuid=end_user %}?redirect=summary">Change<span
                             class="govuk-visually-hidden"> </span></a>
-
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row">
@@ -249,9 +248,8 @@
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <a class="govuk-link"
-                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                           href="{% url 'report_a_breach_where_were_the_goods_supplied_to' end_user_uuid=end_user %}?redirect=summary">Change<span
                             class="govuk-visually-hidden"> </span></a>
-
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row">
@@ -263,9 +261,8 @@
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <a class="govuk-link"
-                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                           href="{% url 'report_a_breach_where_were_the_goods_supplied_to' end_user_uuid=end_user %}?redirect=summary">Change<span
                             class="govuk-visually-hidden"> </span></a>
-
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row">
@@ -277,9 +274,8 @@
                     </dd>
                     <dd class="govuk-summary-list__actions">
                         <a class="govuk-link"
-                           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Change<span
+                           href="{% url 'report_a_breach_where_were_the_goods_supplied_to' end_user_uuid=end_user %}?redirect=summary">Change<span
                             class="govuk-visually-hidden"> </span></a>
-
                     </dd>
                 </div>
             </dl>
@@ -287,7 +283,7 @@
     {% endif %}
     <dl class="govuk-summary-list">
         <a class="govuk-link"
-           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?redirect=summary">Add end-user<span
+           href="{% get_wizard_step_url 'where_were_the_goods_supplied_to' %}?add_another_end_user=yes&redirect=summary">Add end-user<span
             class="govuk-visually-hidden"></span></a>
     </dl>
  {#    TODO: need to add conditional here for other addresses in the supply chain #}


### PR DESCRIPTION
Bugfixes as part of [DST-332](https://uktrade.atlassian.net/browse/DST-332) Check your answers page
- [x] change link for end users - Clicks though to the right screen, but then should go to the address capture screen chosen on the radio button and edits the selected end user rather than create a new one. 

[DST-332]: https://uktrade.atlassian.net/browse/DST-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ